### PR TITLE
Allow insecure connections to vcenter

### DIFF
--- a/manifests/esx/join_vcenter.pp
+++ b/manifests/esx/join_vcenter.pp
@@ -22,7 +22,7 @@ define powercli::esx::join_vcenter (
   $_connect = $powercli::vcenter::connection::connect
 $_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
 
-  notify{"TEST: ${name} || ${_cmd}" : }
+  notify{"TEST: ${name} || ${_connect}" : }
 
   exec { "Join host to cluster - ${name}:":
     command  => "${_connect}; ${_cmd}",

--- a/manifests/esx/join_vcenter.pp
+++ b/manifests/esx/join_vcenter.pp
@@ -22,8 +22,6 @@ define powercli::esx::join_vcenter (
   $_connect = $powercli::vcenter::connection::connect
 $_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
 
-  notify{"TEST: ${name} || ${_connect}" : }
-
   exec { "Join host to cluster - ${name}:":
     command  => "${_connect}; ${_cmd}",
     provider => 'powershell',

--- a/manifests/esx/join_vcenter.pp
+++ b/manifests/esx/join_vcenter.pp
@@ -22,7 +22,12 @@ define powercli::esx::join_vcenter (
   $_connect = $powercli::vcenter::connection::connect
 $_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
 
-  notify{"TEST: ${name} || ${_connect}" : }
+  $test = template('powercli/powercli_esx_join_hosts_to_vcenter_onlyif.ps1.erb')
+
+  notify{"TEST: ${name} || ${test}" : }
+
+
+
 
   exec { "Join host to cluster - ${name}:":
     command  => "${_connect}; ${_cmd}",

--- a/manifests/esx/join_vcenter.pp
+++ b/manifests/esx/join_vcenter.pp
@@ -20,7 +20,9 @@ define powercli::esx::join_vcenter (
 ) {
   include powercli::vcenter::connection
   $_connect = $powercli::vcenter::connection::connect
-  $_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
+$_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
+
+  notify{"TEST: ${name} || ${_cmd}" : }
 
   exec { "Join host to cluster - ${name}:":
     command  => "${_connect}; ${_cmd}",

--- a/manifests/esx/join_vcenter.pp
+++ b/manifests/esx/join_vcenter.pp
@@ -22,13 +22,6 @@ define powercli::esx::join_vcenter (
   $_connect = $powercli::vcenter::connection::connect
 $_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
 
-  $test = template('powercli/powercli_esx_join_hosts_to_vcenter_onlyif.ps1.erb')
-
-  notify{"TEST: ${name} || ${test}" : }
-
-
-
-
   exec { "Join host to cluster - ${name}:":
     command  => "${_connect}; ${_cmd}",
     provider => 'powershell',

--- a/manifests/esx/join_vcenter.pp
+++ b/manifests/esx/join_vcenter.pp
@@ -22,6 +22,8 @@ define powercli::esx::join_vcenter (
   $_connect = $powercli::vcenter::connection::connect
 $_cmd = "Add-VMHost -Name '${name}' -User '${host_user}' -Password '${host_password}' -Location '${host_location}' -Force"
 
+  notify{"TEST: ${name} || ${_connect}" : }
+
   exec { "Join host to cluster - ${name}:":
     command  => "${_connect}; ${_cmd}",
     provider => 'powershell',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,7 @@ class powercli (
       server   => $vcenter_connection['server'],
       username => $vcenter_connection['username'],
       password => $vcenter_connection['password'],
+      insecure => $vcenter_connection['insecure'],
     }
     contain powercli::vcenter::connection
   }

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -7,12 +7,15 @@
 #   Username to use for vCenter authentication
 # @param password
 #   Password to use for vCenter authentication
+# @param insecure
+#   Without this, powercli will be unable to connect to a vcenter without a valid cert.
 #
 # @example Basic usage
 #   class { 'powercli::vcenter::connection':
 #     server   => 'vcenter.domain.tld',
 #     username => 'user@domain.tld',
 #     password => 'PassWord!',
+#     insecure => 'true',  
 #   }
 class powercli::vcenter::connection (
   String $server,

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -18,10 +18,9 @@ class powercli::vcenter::connection (
   String $server,
   String $username,
   String $password,
-  String $insecure,
+  Enum['true', 'false'] $insecure,
 )
 {
-
 
   if $insecure == 'true' {
     $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}' -Force"

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -24,7 +24,7 @@ class powercli::vcenter::connection (
   $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}'"
 
   if $insecure = "true" {
-    $connect = $connect + " -Force"
+    #$connect = $connect + " -Force"
   }
 
 }

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -23,8 +23,8 @@ class powercli::vcenter::connection (
 {
   $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}'"
 
-  if $insecure = "true" {
-    #$connect = $connect + " -Force"
+  if $insecure == 'true' {
+    $connect = $connect + " -Force"
   }
 
 }

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -18,6 +18,13 @@ class powercli::vcenter::connection (
   String $server,
   String $username,
   String $password,
-) {
+  Boolean $insecure,
+)
+{
   $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}'"
+
+  if $insecure = "true" {
+    $connect = $connect + " -Force"
+  }
+
 }

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -18,7 +18,7 @@ class powercli::vcenter::connection (
   String $server,
   String $username,
   String $password,
-  Boolean $insecure,
+  String $insecure,
 )
 {
   $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}'"

--- a/manifests/vcenter/connection.pp
+++ b/manifests/vcenter/connection.pp
@@ -21,10 +21,12 @@ class powercli::vcenter::connection (
   String $insecure,
 )
 {
-  $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}'"
+
 
   if $insecure == 'true' {
-    $connect = $connect + " -Force"
+    $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}' -Force"
   }
-
+  else{
+    $connect = "Connect-VIServer -Server '${server}' -Username '${username}' -Password '${password}'"
+  }
 }

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -4,6 +4,6 @@ Connect-VIServer '<%= @name %>' -User '<%= @username %>' -Password '<%= @passwor
 $HostSNMP = Get-VMHostSNMP
 
 # If you need a way to clear the hosts previous snmp targets
-# Set-VMHostSnmp -HostSnmp $test -ReadOnlyCommunity @()
+# Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
 Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity '<%= @community %>' -TargetCommunity '<%= @community %>' -TargetPort '<%= @port %>' -TargetHost '<%= @target %>' -AddTarget

--- a/types/connection.pp
+++ b/types/connection.pp
@@ -2,4 +2,5 @@ type Powercli::Connection = Struct[{
   server   => String[1],
   username => String[1],
   password => String[1],
+  insecure => String[1],                                 
 }]


### PR DESCRIPTION
PowerCLI changed defaults around in recent versions which changed the behavior when connection to a self signed / insecure certificate on a vcenter. It causes things like `connect-viserver` to fail if there is a self signed cert in place.

You can still make the connection by adding a `-force` onto the cmdlets, this PR allows the user to specify if they wish to use an insecure connection or not