### PR TITLE
Feature/snmp community cleanup

### DIFF
--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -27,21 +27,19 @@ define powercli::esx::snmp (
   $targets,
 )
 {
-  # exec { "${name} Set SNMP targets ${targets}":
-  #   command  => template('powercli/powercli_esx_snmp.ps1.erb'),
-  #   provider => 'powershell',
-  #   onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),
-  # }
-  # powercli::esx::service {"${name} - snmpd":
-  #   service   => 'snmpd',
-  #   host      => $name,
-  #   subscribe => Exec["${name} Set SNMP targets ${targets}"],
-  # }
+  exec { "${name} Set SNMP targets ${targets}":
+    command  => template('powercli/powercli_esx_snmp.ps1.erb'),
+    provider => 'powershell',
+    onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),
+  }
+  powercli::esx::service {"${name} - snmpd":
+    service   => 'snmpd',
+    host      => $name,
+    subscribe => Exec["${name} Set SNMP targets ${targets}"],
+  }
 
-  $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
-
-  notify {"${name} Targets: ${targets}" : }
-
-  notify {"TEST: ${test}" : }
+  # $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
+  # notify {"${name} Targets: ${targets}" : }
+  # notify {"TEST: ${test}" : }
 
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -37,10 +37,4 @@ define powercli::esx::snmp (
     host      => $name,
     subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
-
-  
-
-  #$test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
-  #notify {"TEST: ${test}" : }
-
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -40,7 +40,7 @@ define powercli::esx::snmp (
 
   
 
-  $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
-  notify {"TEST: ${test}" : }
+  #$test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
+  #notify {"TEST: ${test}" : }
 
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -37,7 +37,4 @@ define powercli::esx::snmp (
     host      => $name,
     subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
-  
-  $test = template('powercli/powercli_esx_snmp.ps1.erb')
-  notify {"TEST: ${test}" : }
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -25,17 +25,16 @@ define powercli::esx::snmp (
   $community,
   $port,
   $targets,
-) {
-  $targets.each | $target | {
-    exec { "${name} Set SNMP target ${target}":
-      command  => template('powercli/powercli_esx_snmp.ps1.erb'),
-      provider => 'powershell',
-      onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),
-    }
-    powercli::esx::service {"${name} - snmpd":
-      service   => 'snmpd',
-      host      => $name,
-      subscribe => Exec["${name} Set SNMP target ${target}"],
-    }
+)
+{
+  exec { "${name} Set SNMP target ${targets}":
+    command  => template('powercli/powercli_esx_snmp.ps1.erb'),
+    provider => 'powershell',
+    onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),
+  }
+  powercli::esx::service {"${name} - snmpd":
+    service   => 'snmpd',
+    host      => $name,
+    subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -37,4 +37,8 @@ define powercli::esx::snmp (
     host      => $name,
     subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
+
+
+  $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
+  notify {"TEST: ${test}" : }
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -40,6 +40,8 @@ define powercli::esx::snmp (
 
   $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
 
+  notify {"${name} Targets: ${targets}" : }
+
   notify {"TEST: ${test}" : }
 
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -38,8 +38,9 @@ define powercli::esx::snmp (
     subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
 
-  # $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
-  # notify {"${name} Targets: ${targets}" : }
-  # notify {"TEST: ${test}" : }
+  
+
+  $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
+  notify {"TEST: ${test}" : }
 
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -37,8 +37,4 @@ define powercli::esx::snmp (
     host      => $name,
     subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
-
-
-  $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
-  notify {"TEST: ${test}" : }
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -27,14 +27,19 @@ define powercli::esx::snmp (
   $targets,
 )
 {
-  exec { "${name} Set SNMP targets ${targets}":
-    command  => template('powercli/powercli_esx_snmp.ps1.erb'),
-    provider => 'powershell',
-    onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),
-  }
-  powercli::esx::service {"${name} - snmpd":
-    service   => 'snmpd',
-    host      => $name,
-    subscribe => Exec["${name} Set SNMP targets ${targets}"],
-  }
+  # exec { "${name} Set SNMP targets ${targets}":
+  #   command  => template('powercli/powercli_esx_snmp.ps1.erb'),
+  #   provider => 'powershell',
+  #   onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),
+  # }
+  # powercli::esx::service {"${name} - snmpd":
+  #   service   => 'snmpd',
+  #   host      => $name,
+  #   subscribe => Exec["${name} Set SNMP targets ${targets}"],
+  # }
+
+  $test = template('powercli/powercli_esx_snmp_onlyif.ps1.erb')
+
+  notify {"TEST: ${test}" : }
+
 }

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -27,7 +27,7 @@ define powercli::esx::snmp (
   $targets,
 )
 {
-  exec { "${name} Set SNMP target ${targets}":
+  exec { "${name} Set SNMP targets ${targets}":
     command  => template('powercli/powercli_esx_snmp.ps1.erb'),
     provider => 'powershell',
     onlyif   => template('powercli/powercli_esx_snmp_onlyif.ps1.erb'),

--- a/manifests/esx/snmp.pp
+++ b/manifests/esx/snmp.pp
@@ -37,4 +37,7 @@ define powercli::esx::snmp (
     host      => $name,
     subscribe => Exec["${name} Set SNMP targets ${targets}"],
   }
+  
+  $test = template('powercli/powercli_esx_snmp.ps1.erb')
+  notify {"TEST: ${test}" : }
 }

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -9,6 +9,35 @@ $HostSNMP = Get-VMHostSNMP
 # Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
 # Clear ALL SNMP targets off the host
-# Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
+Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
-Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity '<%= @community %>' -TargetCommunity '<%= @community %>' -TargetPort '<%= @port %>' -TargetHost '<%= @target %>' -AddTarget
+# Create a comma seperated string that contains all SNMP targets defined in hiera
+# This is required because arrays in Puppet look liked ['1.1.1.1', '2.2.2.2'] and you
+# cannot set this to a POSH variable. If you enclose this in quotes you CAN but it makes
+# creating the POSH array even more of a pain.
+$RequestedTargetsCsvString = '<%= @targets.join(",") %>'
+
+# Split the STRING on "," to turn it into a powershell array
+$RequestedTargetsArray = $RequestedTargetsCsvString.Split(",")
+
+# Hashtable of all trap targets we WANT on the host
+$RequestedTargetsHashtable = @{}
+
+# Building the hashtable of the trap targets we WANT on the host
+foreach($t in $RequestedTargetsArray){
+     $TargetObject = new-object PSCustomObject
+     $TargetObject | add-member -membertype noteproperty -name Community -value '<%= @community %>'
+     $TargetObject | add-member -membertype noteproperty -name Port -value '<%= @port %>'
+
+     # Add the TargetObject to the tracking hashtable
+     $RequestedTargetsHashtable.Add($t, $TargetObject)
+}
+
+# Iterate each requested target...
+foreach($t in $RequestedTargetsHashtable){
+
+  # Add the target to the host
+  Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity $t.community -TargetCommunity $t.community -TargetPort $t.port -TargetHost $t.keys -AddTarget
+}
+
+

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -8,4 +8,7 @@ $HostSNMP = Get-VMHostSNMP
 # $HostSNMP = Get-VMHostSNMP
 # Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
+# Clear ALL SNMP targets off the host
+Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
+
 Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity '<%= @community %>' -TargetCommunity '<%= @community %>' -TargetPort '<%= @port %>' -TargetHost '<%= @target %>' -AddTarget

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -36,8 +36,14 @@ foreach($t in $RequestedTargetsArray){
 # Iterate each requested target...
 foreach($t in $RequestedTargetsHashtable){
 
+  # Grabbing the community for the current $t off the $RequestedTargetsHashtable
+  # We do it this way because this does NOT work:
+  # $community = $RequestedTargetsHashtable[$t]['Community'] 
+  $community = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Community
+  $port = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Port
+  
   # Add the target to the host
-  Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity $t.community -TargetCommunity $t.community -TargetPort $t.port -TargetHost $t.keys -AddTarget
+  Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity $community -TargetCommunity $community -TargetPort $port -TargetHost $t -AddTarget
 }
 
 

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -34,7 +34,7 @@ foreach($t in $RequestedTargetsArray){
 }
 
 # Iterate each requested target...
-foreach($t in $RequestedTargetsHashtable){
+foreach($t in $RequestedTargetsHashtable.keys){
 
   # Grabbing the community for the current $t off the $RequestedTargetsHashtable
   # We do it this way because this does NOT work:

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -11,8 +11,8 @@ $HostSNMP = Get-VMHostSNMP
 # Clear ALL SNMP targets off the host
 Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
-# Create a comma seperated string that contains all SNMP targets defined in hiera
-# This is required because arrays in Puppet look liked ['1.1.1.1', '2.2.2.2'] and you
+# Create a comma seperated STRING that contains all SNMP targets defined in hiera
+# This is required because arrays in Puppet look like: ['1.1.1.1', '2.2.2.2'] and you
 # cannot set this to a POSH variable. If you enclose this in quotes you CAN but it makes
 # creating the POSH array even more of a pain.
 $RequestedTargetsCsvString = '<%= @targets.join(",") %>'
@@ -45,5 +45,4 @@ foreach($t in $RequestedTargetsHashtable.keys){
   # Add the target to the host
   Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity $community -TargetCommunity $community -TargetPort $port -TargetHost $t -AddTarget
 }
-
 

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -38,7 +38,7 @@ foreach($t in $RequestedTargetsHashtable.keys){
 
   # Grabbing the community for the current $t off the $RequestedTargetsHashtable
   # We do it this way because this does NOT work:
-  # $community = $RequestedTargetsHashtable[$t]['Community'] 
+  # $community = $RequestedTargetsHashtable[$t]['Community']
   $community = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Community
   $port = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Port
   

--- a/templates/powercli_esx_snmp.ps1.erb
+++ b/templates/powercli_esx_snmp.ps1.erb
@@ -9,6 +9,6 @@ $HostSNMP = Get-VMHostSNMP
 # Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
 # Clear ALL SNMP targets off the host
-Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
+# Set-VMHostSnmp -HostSnmp $HostSNMP -ReadOnlyCommunity @()
 
 Set-VMHostSnmp $HostSNMP -Enabled:$true -ReadOnlyCommunity '<%= @community %>' -TargetCommunity '<%= @community %>' -TargetPort '<%= @port %>' -TargetHost '<%= @target %>' -AddTarget

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -64,12 +64,12 @@ foreach($t in $RequestedTargetsHashtable){
     $CurrentTargetPort = $TargetsHashtable[$t] | select-object -ExpandProperty Port
     
     # If the community is NOT already correct on the host (for the matching target we found)
-    if($RequestedTargetCommunity -neq $CurrentTargetCommunity){
+    if($RequestedTargetCommunity -ne $CurrentTargetCommunity){
       exit 1    
     }
 
     # If the port is NOT already correct on the host (for the matching target we found)
-    if($RequestedTargetPort -neq $CurrentTargetPort){
+    if($RequestedTargetPort -ne $CurrentTargetPort){
       exit 1
     }
   

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -53,7 +53,7 @@ foreach($t in $RequestedTargetsHashtable){
   if($TargetsHashtable.keys -contains $t.keys){
 
     # What we want the community to be for the current $t(arget)
-    $RequestedTargetCommunity = $RequestedTargetHashtable[$t] | select-object -ExpandProperty Community
+    $RequestedTargetCommunity = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Community
     # What we want the port to be for the current $t(arget)
     $RequestedTargetPort = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Port
 

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -42,10 +42,6 @@ foreach($t in $RequestedTargetsArray){
      $RequestedTargetsHashtable.Add($t, $TargetObject)
 }
 
-# if($RequestedTargetsHashtable -eq $TargetsHashtable){
-#     exit 1
-# }
-
 # Comparing the Hash of targets we detected on the host to the Hash of targets already present on the host
 foreach($t in $RequestedTargetsHashtable){
 
@@ -65,18 +61,25 @@ foreach($t in $RequestedTargetsHashtable){
     
     # If the community is NOT already correct on the host (for the matching target we found)
     if($RequestedTargetCommunity -ne $CurrentTargetCommunity){
-      exit 1    
+      # kick off puppet exec run
+      exit 1
     }
 
     # If the port is NOT already correct on the host (for the matching target we found)
     if($RequestedTargetPort -ne $CurrentTargetPort){
+      # kick off puppet exec run
       exit 1
     }
   
   }
   # If the target we want is NOT on the host..
   else{
-    exit 0
+    # kick off puppet exec run  
+    exit 1
   }
 }
+
+# If we made it to this point we have checked every SNMP target on the host and they completely
+# match what is defined in puppet so we exit 1 to let puppet know all is well on this hosts SNMP.
+exit 0
 

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -27,7 +27,7 @@ foreach($t in ($SNMPCheck.TrapTargets)){
 $RequestedTargetsCsvString = '<%= @targets.join(",") %>'
 
 # Split the STRING on "," to turn it into a powershell array
-$RequestedTargetsArray = $$targets_csv_string.Split(",")
+$RequestedTargetsArray = $RequestedTargetsCsvString.Split(",")
 
 # Hashtable of all trap targets we WANT on the host
 $RequestedTargetsHashtable = @{}

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -25,14 +25,18 @@ $RequestedTargetsHashtable = @{}
 
 
 
+# Create a comma seperated string that contains all SNMP targets defined in hiera
+$RequestedTargetsCsvString = '<%= @targets.join(",") %>'
 
-$test_join =<%= @targets.join(",") %>
+# Split the STRING on "," to turn it into a powershell array
+$RequestedTargetsArray = $$targets_csv_string.Split(",")
+
 
 
 
 
 # Building the hashtable of the trap targets we WANT on the host
-foreach($t in <%= @targets %>){
+foreach($t in $RequestedTargetsArray){
      $TargetObject = new-object PSCustomObject
      $TargetObject | add-member -membertype noteproperty -name Community -value '<%= @community %>'
      $TargetObject | add-member -membertype noteproperty -name Port -value '<%= @port %>'

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -23,6 +23,11 @@ foreach($t in ($SNMPCheck.TrapTargets)){
 # Hashtable of all trap targets we WANT on the host
 $RequestedTargetsHashtable = @{}
 
+
+$test = '<%= @targets %>'
+
+
+
 # Building the hashtable of the trap targets we WANT on the host
 foreach($t in '<%= @targets %>'){
      $TargetObject = new-object PSCustomObject

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -20,20 +20,17 @@ foreach($t in ($SNMPCheck.TrapTargets)){
      $TargetsHashtable.Add($t.HostName, $TargetObject)
 }
 
-# Hashtable of all trap targets we WANT on the host
-$RequestedTargetsHashtable = @{}
-
-
-
 # Create a comma seperated string that contains all SNMP targets defined in hiera
+# This is required because arrays in Puppet look liked ['1.1.1.1', '2.2.2.2'] and you
+# cannot set this to a POSH variable. If you enclose this in quotes you CAN but it makes
+# creating the POSH array even more of a pain.
 $RequestedTargetsCsvString = '<%= @targets.join(",") %>'
 
 # Split the STRING on "," to turn it into a powershell array
 $RequestedTargetsArray = $$targets_csv_string.Split(",")
 
-
-
-
+# Hashtable of all trap targets we WANT on the host
+$RequestedTargetsHashtable = @{}
 
 # Building the hashtable of the trap targets we WANT on the host
 foreach($t in $RequestedTargetsArray){
@@ -51,28 +48,3 @@ if($RequestedTargetsHashtable -eq $TargetsHashtable){
 
 exit 0
 
-
-
-# # If the target we want on the host IS already there...
-# if(($SNMPCheck.TrapTargets.HostName) -contains '<%= @target %>'){
-
-#      # Select that target specifically from the hashtable
-#      $TargetCheck = $TargetsHashtable['<%= @target %>']
-
-#      # If the target on the host has a DIFFERENT port than what we want...
-#      if(($TargetCheck.Port) -ne '<%= @port %>'){
-#          exit 0
-#      }
-
-#      # If the target on the host has a DIFFERENT community than we want...
-#      if(($TargetCheck.Community) -ne '<%= @community %>'){
-#          exit 0
-#      }
-# }
-# # If the target we want on the host is NOT there...
-# else{
-#     exit 0
-# }
-
-# If we found no problems with SNMP targets
-# exit 1

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -7,21 +7,39 @@ if(($SNMPCheck.Enabled) -ne 'True'){
      exit 0
 }
 
-if(($SNMPCheck.Port) -ne '<%= @port %>'){
-     exit 0
-}
+# Array of all trap targets 
+$TargetsHashtable = @{}
 
+# Building a dict of current trap targets on the host - we'll use this to compare
 foreach($t in ($SNMPCheck.TrapTargets)){
-    
-    if(($t.HostName) -ne '<%= @target %>'){
-         exit 0
-    }
-    if(($t.Community) -ne '<%= @community %>'){
-         exit 0
-    }
-    if(($t.Port) -ne '<%= @port %>'){
-         exit 0
-    }
+     $TargetObject = new-object PSCustomObject
+     $TargetObject | add-member -membertype noteproperty -name Community -value $t.Community
+     $TargetObject | add-member -membertype noteproperty -name Port -value $t.Port
+
+     # Add this object to the tracking hashtable
+     $TargetsHashtable.Add($t.HostName, $TargetObject)
 }
 
+# If the target we want on the host IS already there...
+if(($SNMPCheck.TrapTargets.HostName) -contains '<%= @target %>'){
+
+     # Select that target specifically from the hashtable
+     $TargetCheck = $TargetsHashtable['<%= @target %>']
+
+     # If the target on the host has a DIFFERENT port than what we want...
+     if(($TargetCheck.Port) -ne '<%= @port %>'){
+         exit 0
+     }
+
+     # If the target on the host has a DIFFERENT community than we want...
+     if(($TargetCheck.Community) -ne '<%= @community %>'){
+         exit 0
+     }
+}
+# If the target we want on the host is NOT there...
+else{
+    exit 0
+}
+
+# If we found no problems with SNMP targets
 exit 1

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -88,7 +88,7 @@ foreach($t in $RequestedTargetsHashtable){
 # If there were any 'extra' targets present on the host but didn't have a match in puppet,
 # kick off a puppet run (this "cleans" the host of dirty SNMP targets)
 if($TargetsHashtable.Count -gt 0){
-  write-host "exit 0"
+  exit 0
 }
 
 

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -42,9 +42,41 @@ foreach($t in $RequestedTargetsArray){
      $RequestedTargetsHashtable.Add($t, $TargetObject)
 }
 
-if($RequestedTargetsHashtable -eq $TargetsHashtable){
-    exit 1
-}
+# if($RequestedTargetsHashtable -eq $TargetsHashtable){
+#     exit 1
+# }
 
-exit 0
+# Comparing the Hash of targets we detected on the host to the Hash of targets already present on the host
+foreach($t in $RequestedTargetsHashtable){
+
+  # If the current $t(arget) we want is already on the host...
+  if($TargetsHashtable.keys -contains $t.keys){
+
+    # What we want the community to be for the current $t(arget)
+    $RequestedTargetCommunity = $RequestedTargetHashtable[$t] | select-object -ExpandProperty Community
+    # What we want the port to be for the current $t(arget)
+    $RequestedTargetPort = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Port
+
+    # What the community is set to on the host currently (for the matching target we found)
+    $CurrentTargetCommunity = $TargetsHashtable[$t] | select-object -ExpandProperty Community
+    
+    # What the port is set to on the host currently (for the matching target we found)
+    $CurrentTargetPort = $TargetsHashtable[$t] | select-object -ExpandProperty Port
+    
+    # If the community is NOT already correct on the host (for the matching target we found)
+    if($RequestedTargetCommunity -neq $CurrentTargetCommunity){
+      exit 1    
+    }
+
+    # If the port is NOT already correct on the host (for the matching target we found)
+    if($RequestedTargetPort -neq $CurrentTargetPort){
+      exit 1
+    }
+  
+  }
+  # If the target we want is NOT on the host..
+  else{
+    exit 0
+  }
+}
 

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -23,7 +23,13 @@ foreach($t in ($SNMPCheck.TrapTargets)){
 # Hashtable of all trap targets we WANT on the host
 $RequestedTargetsHashtable = @{}
 
-$test_join = {{ <%= @targets %>|join(',') }}
+
+
+
+$test_join =<%= @targets.join(",") %>
+
+
+
 
 # Building the hashtable of the trap targets we WANT on the host
 foreach($t in <%= @targets %>){

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -62,24 +62,24 @@ foreach($t in $RequestedTargetsHashtable){
     # If the community is NOT already correct on the host (for the matching target we found)
     if($RequestedTargetCommunity -ne $CurrentTargetCommunity){
       # kick off puppet exec run
-      exit 1
+      exit 0
     }
 
     # If the port is NOT already correct on the host (for the matching target we found)
     if($RequestedTargetPort -ne $CurrentTargetPort){
       # kick off puppet exec run
-      exit 1
+      exit 0
     }
   
   }
   # If the target we want is NOT on the host..
   else{
     # kick off puppet exec run  
-    exit 1
+    exit 0
   }
 }
 
 # If we made it to this point we have checked every SNMP target on the host and they completely
 # match what is defined in puppet so we exit 1 to let puppet know all is well on this hosts SNMP.
-exit 0
+exit 1
 

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -49,6 +49,8 @@ foreach($t in $RequestedTargetsHashtable){
   if($TargetsHashtable.keys -contains $t.keys){
 
     # What we want the community to be for the current $t(arget)
+    # We do it this way because this does NOT work:
+    # $community = $RequestedTargetsHashtable[$t]['Community']
     $RequestedTargetCommunity = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Community
     # What we want the port to be for the current $t(arget)
     $RequestedTargetPort = $RequestedTargetsHashtable[$t] | select-object -ExpandProperty Port

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -7,10 +7,10 @@ if(($SNMPCheck.Enabled) -ne 'True'){
      exit 0
 }
 
-# Array of all trap targets 
+# Hashtable of all trap targets on the host currently
 $TargetsHashtable = @{}
 
-# Building a dict of current trap targets on the host - we'll use this to compare
+# Building a hashtable of current trap targets on the host
 foreach($t in ($SNMPCheck.TrapTargets)){
      $TargetObject = new-object PSCustomObject
      $TargetObject | add-member -membertype noteproperty -name Community -value $t.Community
@@ -20,26 +20,47 @@ foreach($t in ($SNMPCheck.TrapTargets)){
      $TargetsHashtable.Add($t.HostName, $TargetObject)
 }
 
-# If the target we want on the host IS already there...
-if(($SNMPCheck.TrapTargets.HostName) -contains '<%= @target %>'){
+# Hashtable of all trap targets we WANT on the host
+$RequestedTargetsHashtable = @{}
 
-     # Select that target specifically from the hashtable
-     $TargetCheck = $TargetsHashtable['<%= @target %>']
+# Building the hashtable of the trap targets we WANT on the host
+foreach($t in '<%= @targets %>'){
+     $TargetObject = new-object PSCustomObject
+     $TargetObject | add-member -membertype noteproperty -name Community -value '<%= @community %>'
+     $TargetObject | add-member -membertype noteproperty -name Port -value '<%= @port %>'
 
-     # If the target on the host has a DIFFERENT port than what we want...
-     if(($TargetCheck.Port) -ne '<%= @port %>'){
-         exit 0
-     }
-
-     # If the target on the host has a DIFFERENT community than we want...
-     if(($TargetCheck.Community) -ne '<%= @community %>'){
-         exit 0
-     }
+     # Add the TargetObject to the tracking hashtable
+     $RequestedTargetsHashtable.Add($t, $TargetObject)
 }
-# If the target we want on the host is NOT there...
-else{
-    exit 0
+
+if($RequestedTargetsHashtable -eq $TargetsHashtable){
+    exit 1
 }
+
+exit 0
+
+
+
+# # If the target we want on the host IS already there...
+# if(($SNMPCheck.TrapTargets.HostName) -contains '<%= @target %>'){
+
+#      # Select that target specifically from the hashtable
+#      $TargetCheck = $TargetsHashtable['<%= @target %>']
+
+#      # If the target on the host has a DIFFERENT port than what we want...
+#      if(($TargetCheck.Port) -ne '<%= @port %>'){
+#          exit 0
+#      }
+
+#      # If the target on the host has a DIFFERENT community than we want...
+#      if(($TargetCheck.Community) -ne '<%= @community %>'){
+#          exit 0
+#      }
+# }
+# # If the target we want on the host is NOT there...
+# else{
+#     exit 0
+# }
 
 # If we found no problems with SNMP targets
-exit 1
+# exit 1

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -23,10 +23,7 @@ foreach($t in ($SNMPCheck.TrapTargets)){
 # Hashtable of all trap targets we WANT on the host
 $RequestedTargetsHashtable = @{}
 
-
-$test = <%= @targets %>
-
-
+$test_join = {{ <%= @targets %>|join(',') }}
 
 # Building the hashtable of the trap targets we WANT on the host
 foreach($t in <%= @targets %>){

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -24,12 +24,12 @@ foreach($t in ($SNMPCheck.TrapTargets)){
 $RequestedTargetsHashtable = @{}
 
 
-$test = '<%= @targets %>'
+$test = <%= @targets %>
 
 
 
 # Building the hashtable of the trap targets we WANT on the host
-foreach($t in '<%= @targets %>'){
+foreach($t in <%= @targets %>){
      $TargetObject = new-object PSCustomObject
      $TargetObject | add-member -membertype noteproperty -name Community -value '<%= @community %>'
      $TargetObject | add-member -membertype noteproperty -name Port -value '<%= @port %>'

--- a/templates/powercli_esx_snmp_onlyif.ps1.erb
+++ b/templates/powercli_esx_snmp_onlyif.ps1.erb
@@ -70,7 +70,13 @@ foreach($t in $RequestedTargetsHashtable){
       # kick off puppet exec run
       exit 0
     }
-  
+    # Grab the STRING that is the target IP of our current $t(arget)
+    $TargetIP = $t.keys
+
+    # We have validated that the matching $t(arget) we found on the host matches what puppet
+    # wants present on the host (for this target), so we remove this $t(arget) from the hashtable
+    # to keep track of any 'extra' targets that might be present on the host but ARENT in puppet
+    $TargetsHashtable.Remove("$TargetIP")
   }
   # If the target we want is NOT on the host..
   else{
@@ -78,6 +84,13 @@ foreach($t in $RequestedTargetsHashtable){
     exit 0
   }
 }
+
+# If there were any 'extra' targets present on the host but didn't have a match in puppet,
+# kick off a puppet run (this "cleans" the host of dirty SNMP targets)
+if($TargetsHashtable.Count -gt 0){
+  write-host "exit 0"
+}
+
 
 # If we made it to this point we have checked every SNMP target on the host and they completely
 # match what is defined in puppet so we exit 1 to let puppet know all is well on this hosts SNMP.


### PR DESCRIPTION
This PR gives much better functionality to the SNMP resource.

- FEATURE: We can support multiple SNMP targets now. Puppet checks each individual target to ensure that the community and port has not changed for each respective target. 
- FEATURE: Puppet will trigger the `exec` command if there are any "dirty" SNMP targets on the host. This means the host's SNMP targets are identical to what is defined in Hiera after Puppet runs.
- BUG FIX: It will no longer add "the correct" SNMP server to the systems if there are any "bad" SNMP targets on the host currently, previously this would occur unless the *only* SNMP targets on the hosts were the SNMP targets defined in Puppet / Hiera
