### PR TITLE
dvs add hosts rewrite

### DIFF
--- a/manifests/esx/dvs_add_hosts.pp
+++ b/manifests/esx/dvs_add_hosts.pp
@@ -1,5 +1,7 @@
 # @summary Resource that manages ESX DvSwitch Host membership
 #
+# @param esx_host
+#   Name or IP address of the ESX host you would like joined to the dvswitch.
 # @param dvswitch_name
 #   Name of the dvs.
 # @param dvswitch_nic_defaults
@@ -21,6 +23,7 @@
 #
 # @example Basic usage - Using Default NICs on host. This will attach vmnic0 & 1 to the dvs.
 #   powercli::esx::dvs_add_hosts {'my-vmware-host.fqdn.tld':
+#     esx_host      => 'my_esx_hostname_or_ip_here',
 #     dvswitch_name => 'my_dvswitch_name_here',
 #     dvswitch_nic_defaults => {
 #     'my_dvswitch_name_here' => {
@@ -33,6 +36,7 @@
 #   }
 # @example Override usage - Using Override NICs on host. This will attach vmnic2 & 3 to the dvs.
 #   powercli::esx::dvs_add_hosts {'my-special-vmware-host.fqdn.tld':
+#     esx_host      => 'my_esx_hostname_or_ip_here',
 #     dvswitch_name => 'my_dvswitch_name_here',
 #     dvswitch_nic_defaults => {
 #     'my_dvswitch_name_here' => {

--- a/manifests/esx/dvs_add_hosts.pp
+++ b/manifests/esx/dvs_add_hosts.pp
@@ -64,7 +64,7 @@ define powercli::esx::dvs_add_hosts (
 
   include powercli::vcenter::connection
   $_connect = $powercli::vcenter::connection::connect
-    
+
   # This returns null if the host does not have 'vswitches' (both standard and distributed) overrides set.
   $current_server_overrides = $overrides[$esx_host]['vswitches']
 

--- a/manifests/esx/dvs_add_hosts.pp
+++ b/manifests/esx/dvs_add_hosts.pp
@@ -52,6 +52,7 @@
 #     }
 #   }
 define powercli::esx::dvs_add_hosts (
+  $esx_host,
   $dvswitch_name,
   $dvswitch_nic_defaults,
   $overrides
@@ -59,9 +60,9 @@ define powercli::esx::dvs_add_hosts (
 
   include powercli::vcenter::connection
   $_connect = $powercli::vcenter::connection::connect
-
+    
   # This returns null if the host does not have 'vswitches' (both standard and distributed) overrides set.
-  $current_server_overrides = $overrides[$name]['vswitches']
+  $current_server_overrides = $overrides[$esx_host]['vswitches']
 
   #if the server had ANY overrides for vswitches...
   if $current_server_overrides {

--- a/templates/powercli_esx_dvs_add_hosts.ps1.erb
+++ b/templates/powercli_esx_dvs_add_hosts.ps1.erb
@@ -1,10 +1,10 @@
 <%= @_connect %>
 
 # Add host to dvswitch
-Add-VDSwitchVMHost -VDSwitch '<%= @dvswitch_name %>' -VMHost '<%= @name %>'
+Add-VDSwitchVMHost -VDSwitch '<%= @dvswitch_name %>' -VMHost '<%= @esx_host %>'
 
 # Get the NIC we want as an uplink to dvswitch
-$Uplink = Get-VMHostNetworkAdapter -VMHost '<%= @name %>' -Physical -name '<%= @nic %>'
+$Uplink = Get-VMHostNetworkAdapter -VMHost '<%= @esx_host %>' -Physical -name '<%= @nic %>'
 
 # Assign uplink to dvswitch
 Get-VDSwitch -Name '<%= @dvswitch_name %>' | Add-VDSwitchPhysicalNetworkAdapter -VMHostPhysicalNic $Uplink -Confirm:$false

--- a/templates/powercli_esx_dvs_add_hosts_onlyif.ps1.erb
+++ b/templates/powercli_esx_dvs_add_hosts_onlyif.ps1.erb
@@ -10,7 +10,7 @@ foreach($u in $DvUplinks){
     $VMHost = $u.ProxyHost.Name
 
     # If we found the specific uplink for the specific vmhost already configured as an uplink...
-    if($Uplink -eq '<%= @nic %>' -and $VMHost -eq '<%= @name %>'){
+    if($Uplink -eq '<%= @nic %>' -and $VMHost -eq '<%= @esx_host %>'){
         # Exit 1 so puppet skips this uplink
         exit 1
     }


### PR DESCRIPTION
Changed this resource to get the ESX host it is joining to the dvswitch as a parameter rather than the name of the resource which prevented us from using the resource on the same host multiple times (if we wanted to join the same host to multiple dvswitches)